### PR TITLE
Fix $default handling when not using $range

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -97,14 +97,16 @@ internals.filter = function (node, criteria, applied) {
 
     if (criterion !== undefined) {
         if (!node.$range) {
-            internals.logApplied(applied, filter, node, criterion);
-            return internals.filter(node[criterion], criteria, applied);
-        }
-
-        for (var i = 0, il = node.$range.length; i < il; ++i) {
-            if (criterion <= node.$range[i].limit) {
-                internals.logApplied(applied, filter, node, node.$range[i]);
-                return internals.filter(node.$range[i].value, criteria, applied);
+            if (node[criterion] != null) {
+                internals.logApplied(applied, filter, node, criterion);
+                return internals.filter(node[criterion], criteria, applied);
+            }
+        } else {
+            for (var i = 0, il = node.$range.length; i < il; ++i) {
+                if (criterion <= node.$range[i].limit) {
+                    internals.logApplied(applied, filter, node, node.$range[i]);
+                    return internals.filter(node.$range[i].value, criteria, applied);
+                }
             }
         }
 

--- a/test/store.js
+++ b/test/store.js
@@ -39,6 +39,7 @@ describe('Confidence', function () {
                     // Filter
                     $filter: 'platform',
                     ios: 1,                     // Value
+                    not_android: false,         // Value
                     $default: 2                 // Value
                 }
             },
@@ -97,6 +98,8 @@ describe('Confidence', function () {
             get('/key1', 'abc');
             get('/key2', 2, null, [{ filter: 'env', valueId: '$default' }, { filter: 'platform', valueId: '$default' }]);
             get('/key2', 1, { platform: 'ios' });
+            get('/key2', false, { platform: 'not_android' });
+            get('/key2', 2, { platform: 'the other one' });
             get('/key2/deeper', 'value', { env: 'production' });
             get('/key2/deeper', undefined, { env: 'qa' });
             get('/key2/deeper', undefined);


### PR DESCRIPTION
Previously when a filter is defined but does not match any of the defined key
values the $default failover would not occur.
