### PR TITLE
Issue 70: Document array behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,14 +530,23 @@ If you have values that you would like to share between various configuration ob
 {
   "$filter": "env",
   "$base": {
-      "logLocation": "/logs"
+      "logLocation": "/logs",
+      "flags": ["a", "b"],
+      "tags": {
+          "$value": ["DEBUG"],
+          "$replace": true
+      }
   },
   "production":  {
-      "logLevel": "error"
+      "logLevel": "error",
+      "flags": ["c", "d"],
+      "tags": ["INFO", "ERROR"]
   },
   "qa":  {
       "logLevel": "info",
-      "logLocation": "/qa/logs"
+      "logLocation": "/qa/logs",
+      "flags": ["e", "f"],
+      "tags": ["DEBUG"]
   },
   "staging":  {
       "logLevel": "debug"
@@ -553,7 +562,9 @@ When requesting the **key** `/` with:
 ```json
 {
 	"logLevel": "error",
-	"logLocation": "/logs"
+	"logLocation": "/logs",
+    "flags": ["a", "b", "c", "d"],
+    "tags": ["INFO", "ERROR"]
 }
 ```
 
@@ -565,11 +576,15 @@ However when requesting the **key** `/` with:
 ```json
 {
 	"logLevel": "debug",
-	"logLocation": "/logs"
+	"logLocation": "/logs",
+    "flags": ["a", "b"],
+    "tags": ["DEBUG"],
 }
 ```
 
-If the same key occurs in `$base` and the `filtered value` then value in `$base` will be overridden.
+If the same key occurs in `$base` and the `filtered value`:
+- for objects, the value in `$base` will be overridden.
+- for arrays, the arrays are merged unless the `$base` array is specified with the `$value` key and the `$replace` flag as shown above.
 
 In the above sample, when requesting the **key** `/` with:
 

--- a/bin/confidence
+++ b/bin/confidence
@@ -4,6 +4,7 @@
 // Load modules
 
 const Fs = require('fs');
+const Path = require('path');
 const Yargs = require('yargs');
 const Alce = require('alce');
 const Confidence = require('../');
@@ -28,7 +29,7 @@ internals.argv = Yargs.usage('Usage: $0 -c config.json [--filter.criterion=value
 
 internals.getConfig = function () {
 
-    const configPath = !internals.argv.c.startsWith('/') ? process.cwd() + '/' + internals.argv.c : internals.argv.c;
+    const configPath = Path.resolve(internals.argv.c);
 
     return new Promise((resolve, reject) => {
 
@@ -64,7 +65,7 @@ internals.generate = async () => {
         process.stdout.write(JSON.stringify(set, null, indentation));
     }
     catch (err) {
-        console.log('Failed loading configuration file: ' + internals.argv.c + ' (' + err.isJoi ? err.annotate() : err.message + ')');
+        process.stderr.write('Failed loading configuration file: ' + internals.argv.c + ' (' + /*err.isJoi ? err.annotate() :*/ err.message + ')');
         process.exit(1);
     }
 };

--- a/bin/confidence
+++ b/bin/confidence
@@ -65,7 +65,7 @@ internals.generate = async () => {
         process.stdout.write(JSON.stringify(set, null, indentation));
     }
     catch (err) {
-        process.stderr.write('Failed loading configuration file: ' + internals.argv.c + ' (' + /*err.isJoi ? err.annotate() :*/ err.message + ')');
+        process.stderr.write('Failed loading configuration file: ' + internals.argv.c + ' (' + err + ')');
         process.exit(1);
     }
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -92,21 +92,24 @@ internals.Joi = Joi.extend([
     }
 ]);
 
-internals.alternatives = internals.Joi.lazy(() => {
+internals.alternatives = (additionalSchema) => {
 
-    return internals.Joi.alternatives([
-        internals.store,
-        internals.Joi.string().allow(''),
-        internals.Joi.number(),
-        internals.Joi.boolean(),
-        internals.Joi.array(),
-        internals.Joi.func()
-    ]);
-});
+    return internals.Joi.lazy(() => {
+
+        return internals.Joi.alternatives([
+            additionalSchema ? internals.store.keys(additionalSchema) : internals.store,
+            internals.Joi.string().allow(''),
+            internals.Joi.number(),
+            internals.Joi.boolean(),
+            internals.Joi.array(),
+            internals.Joi.func()
+        ]);
+    });
+};
 
 exports.store = internals.store = internals.Joi.object().keys({
     $param: internals.Joi.string().regex(/^\w+(?:\.\w+)*$/, { name: 'Alphanumeric Characters and "_"' }),
-    $value: internals.alternatives,
+    $value: internals.alternatives(),
     $env: internals.Joi.string().regex(/^\w+$/, { name: 'Alphanumeric Characters and "_"' }),
     $coerce: internals.Joi.string().valid('number'),
     $filter: internals.Joi.alternatives([
@@ -115,19 +118,22 @@ exports.store = internals.store = internals.Joi.object().keys({
             $env: internals.Joi.string().regex(/^\w+$/, { name: 'Alphanumeric Characters and "_"' }).required()
         })
     ]),
-    $base: internals.alternatives,
-    $default: internals.alternatives,
+    $base: internals.alternatives({
+        $value: internals.Joi.array(),
+        $replace: internals.Joi.boolean().invalid(false) // TODO: could instead be $merge disallowing 'true'
+    }),
+    $default: internals.alternatives(),
     $id: internals.Joi.string(),
     $range: internals.Joi.array().items(
         internals.Joi.object().keys({
             limit: internals.Joi.number().required(),
-            value: internals.alternatives.required(),
+            value: internals.alternatives().required(),
             id: internals.Joi.string().optional()
         })
     ).sorted((a, b) => a.limit < b.limit, '"entry.limit" in Ascending order' ).min(1),
     $meta: internals.Joi.alternatives([Joi.object(), Joi.string()])
 })
-    .pattern(/^[^\$].*$/, internals.alternatives)
+    .pattern(/^[^\$].*$/, internals.alternatives())
     .notInstanceOf(Error)
     .notInstanceOf(RegExp)
     .notInstanceOf(Date)
@@ -141,7 +147,7 @@ exports.store = internals.store = internals.Joi.object().keys({
     .with('$range', '$filter')
     .with('$base', '$filter')
     .with('$coerce', '$env')
+    .with('$replace', '$value')
     .withPattern('$filter', /^((\$range)|([^\$].*))$/, { inverse: true, name: '$filter with a valid value OR $range' })
     .withPattern('$range', /^([^\$].*)$/, { name: '$range with non-ranged values' })
     .allow(null);
-

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -14,7 +14,8 @@ internals.Joi = Joi.extend([
         base: Joi.object(),
         language: {
             withPattern: 'fails to match the {{name}} pattern',
-            notInstanceOf: 'cannot be an instance of {{name}}'
+            notInstanceOf: 'cannot be an instance of {{name}}',
+            replaceBaseArrayFlag: '{{desc}}'
         },
         rules: [
             {
@@ -59,6 +60,28 @@ internals.Joi = Joi.extend([
 
                     return value;
                 }
+            },
+            {
+                name: 'replaceBaseArrayFlag',
+                params: {},
+                validate(_params, value, state, options) {
+
+                    if (Object.keys(value).includes('$replace')) {
+                        if (!state.path.includes('$base')) {
+                            return this.createError('object.replaceBaseArrayFlag', { desc: '$replace only allowed under path $base' }, state, options);
+                        }
+
+                        if (!Object.keys(value).includes('$value')) {
+                            return this.createError('object.replaceBaseArrayFlag', { desc: '$replace missing required peer $value' }, state, options);
+                        }
+
+                        if (!Array.isArray(value.$value)) {
+                            return this.createError('object.replaceBaseArrayFlag', { desc: '$replace requires $value to be an array' }, state, options);
+                        }
+                    }
+
+                    return value;
+                }
             }
         ]
     },
@@ -92,24 +115,22 @@ internals.Joi = Joi.extend([
     }
 ]);
 
-internals.alternatives = (additionalSchema) => {
+internals.alternatives = internals.Joi.lazy(() => {
 
-    return internals.Joi.lazy(() => {
-
-        return internals.Joi.alternatives([
-            additionalSchema ? internals.store.keys(additionalSchema) : internals.store,
-            internals.Joi.string().allow(''),
-            internals.Joi.number(),
-            internals.Joi.boolean(),
-            internals.Joi.array(),
-            internals.Joi.func()
-        ]);
-    });
-};
+    return internals.Joi.alternatives([
+        internals.store,
+        internals.Joi.string().allow(''),
+        internals.Joi.number(),
+        internals.Joi.boolean(),
+        internals.Joi.array(),
+        internals.Joi.func()
+    ]);
+});
 
 exports.store = internals.store = internals.Joi.object().keys({
     $param: internals.Joi.string().regex(/^\w+(?:\.\w+)*$/, { name: 'Alphanumeric Characters and "_"' }),
-    $value: internals.alternatives(),
+    $value: internals.alternatives,
+    $replace: internals.Joi.boolean().invalid(false),
     $env: internals.Joi.string().regex(/^\w+$/, { name: 'Alphanumeric Characters and "_"' }),
     $coerce: internals.Joi.string().valid('number'),
     $filter: internals.Joi.alternatives([
@@ -118,22 +139,19 @@ exports.store = internals.store = internals.Joi.object().keys({
             $env: internals.Joi.string().regex(/^\w+$/, { name: 'Alphanumeric Characters and "_"' }).required()
         })
     ]),
-    $base: internals.alternatives({
-        $value: internals.Joi.array(),
-        $replace: internals.Joi.boolean().invalid(false) // TODO: could instead be $merge disallowing 'true'
-    }),
-    $default: internals.alternatives(),
+    $base: internals.alternatives,
+    $default: internals.alternatives,
     $id: internals.Joi.string(),
     $range: internals.Joi.array().items(
         internals.Joi.object().keys({
             limit: internals.Joi.number().required(),
-            value: internals.alternatives().required(),
+            value: internals.alternatives.required(),
             id: internals.Joi.string().optional()
         })
     ).sorted((a, b) => a.limit < b.limit, '"entry.limit" in Ascending order' ).min(1),
     $meta: internals.Joi.alternatives([Joi.object(), Joi.string()])
 })
-    .pattern(/^[^\$].*$/, internals.alternatives())
+    .pattern(/^[^\$].*$/, internals.alternatives)
     .notInstanceOf(Error)
     .notInstanceOf(RegExp)
     .notInstanceOf(Date)
@@ -147,7 +165,7 @@ exports.store = internals.store = internals.Joi.object().keys({
     .with('$range', '$filter')
     .with('$base', '$filter')
     .with('$coerce', '$env')
-    .with('$replace', '$value')
     .withPattern('$filter', /^((\$range)|([^\$].*))$/, { inverse: true, name: '$filter with a valid value OR $range' })
     .withPattern('$range', /^([^\$].*)$/, { name: '$range with non-ranged values' })
+    .replaceBaseArrayFlag()
     .allow(null);

--- a/lib/store.js
+++ b/lib/store.js
@@ -108,8 +108,9 @@ internals.defaults = function (node, base) {
 
     base = base || {};
 
-    if (typeof node === 'object' && (Array.isArray(base) === Array.isArray(node))) {
-        return Hoek.merge(Hoek.clone(base), Hoek.clone(node));
+    const filteredBase = internals.filter(base);
+    if (typeof node === 'object' && (Array.isArray(filteredBase) === Array.isArray(node)) && !base.$replace) {
+        return Hoek.merge(Hoek.clone(filteredBase), Hoek.clone(node));
     }
 
     return node;

--- a/test/bin.js
+++ b/test/bin.js
@@ -84,8 +84,6 @@ describe('bin', () => {
 
     before(() => {
 
-        Fs.writeFileSync(configPath + '.dpm', JSON.stringify(tree, null, 2), { encoding: 'utf8' }); // TODO: remove
-
         return new Promise((resolve) => {
 
             const stream = Fs.createWriteStream(configPath);

--- a/test/bin.js
+++ b/test/bin.js
@@ -84,6 +84,8 @@ describe('bin', () => {
 
     before(() => {
 
+        Fs.writeFileSync(configPath + '.dpm', JSON.stringify(tree, null, 2), { encoding: 'utf8' }); // TODO: remove
+
         return new Promise((resolve) => {
 
             const stream = Fs.createWriteStream(configPath);
@@ -176,6 +178,7 @@ describe('bin', () => {
 
         return new Promise((resolve) => {
 
+            const errors = [];
             const confidence = ChildProcess.spawn('node', [confidencePath, '-c', configPath, '--filter.env', 'production', '-i', 'someString']);
 
             confidence.stdout.on('data', (data) => {
@@ -186,10 +189,38 @@ describe('bin', () => {
             confidence.stderr.on('data', (data) => {
 
                 expect(data.toString()).to.exist();
+                errors.push(data.toString());
             });
 
             confidence.on('close', () => {
 
+                expect(errors.join('')).to.match(/Argument check failed[\s\S]*indentation/);
+                resolve();
+            });
+        });
+    });
+
+    it('fails when configuration file cannot be found', () => {
+
+        return new Promise((resolve) => {
+
+            const errors = [];
+            const confidence = ChildProcess.spawn('node', [confidencePath, '-c', 'doesNotExist', '--filter.env', 'production', '-i', 2]);
+
+            confidence.stdout.on('data', (data) => {
+
+                expect(data.toString()).to.not.exist();
+            });
+
+            confidence.stderr.on('data', (data) => {
+
+                expect(data.toString()).to.exist();
+                errors.push(data.toString());
+            });
+
+            confidence.on('close', () => {
+
+                expect(errors.join('')).to.match(/Failed loading configuration file: doesNotExist/);
                 resolve();
             });
         });

--- a/test/store.js
+++ b/test/store.js
@@ -203,7 +203,6 @@ describe('get()', () => {
     get('/key11', { a: 'env', b: '3000', port: 4000 }, {}, [], { KEY1: 'env', KEY2: 3000, PORT: '4000' });
     get('/key11', { a: 'env', b: '3000', port: 3000 }, {}, [], { KEY1: 'env', KEY2: 3000, PORT: 'abc' });
 
-    // TODO: adjust these tests to exclude the new values
     const slashResult = {
         key1: 'abc',
         key10: { b: 123 },

--- a/test/store.js
+++ b/test/store.js
@@ -146,6 +146,13 @@ const tree = {
         ],
         $default: 6
     },
+    // TODO: name these tests better, and wrap them in something that will exclude the values for the overall '/' test.
+    dpm1a: { $filter: 'env', $base: { $value: ['a'], $replace: true }, $default: { $value: ['b'] }, dev: {} },
+    dpm1b: { $filter: 'env', $base: { $value: ['a'], $replace: true }, $default:           ['b'],   dev: {} },
+    dpm2a: { $filter: 'env', $base: { $value: ['a']                 }, $default: { $value: ['b'] }, dev: {} },
+    dpm2b: { $filter: 'env', $base: { $value: ['a']                 }, $default:           ['b'],   dev: {} },
+    dpm3:  { $filter: 'env', $base:           ['a'],                   $default: { $value: ['b'] }, dev: {} },
+    dpm4:  { $filter: 'env', $base:           ['a'],                   $default:           ['b'],   dev: {} },
     noProto: Object.create(null),
     $meta: {
         something: 'else'
@@ -194,8 +201,11 @@ describe('get()', () => {
     get('/key11', { a: 'env', b: 'abc', port: 3000 }, {}, [], { KEY1: 'env' });
     get('/key11', { a: 'env', b: '3000', port: 4000 }, {}, [], { KEY1: 'env', KEY2: 3000, PORT: '4000' });
     get('/key11', { a: 'env', b: '3000', port: 3000 }, {}, [], { KEY1: 'env', KEY2: 3000, PORT: 'abc' });
+
+    // TODO: adjust these tests to exclude the new values
     get('/', { key1: 'abc', key10: { b: 123 }, key11: { b: 'abc', port: 3000 }, key2: 2, key3: { sub1: 0 }, key4: [12, 13, 14], key5: {}, noProto: {}, ab: 6 });
     get('/', { key1: 'abc', key10: { b: 123 }, key11: { b: 'abc', port: 3000 }, key2: 2, key3: { sub1: 0, sub2: '' }, key4: [12, 13, 14], key5: {}, noProto: {}, ab: 6 }, { xfactor: 'yes' });
+
     get('/ab', 2, { random: { 1: 2 } }, [{ filter: 'random.1', valueId: '[object]', filterId: 'random_ab_test' }]);
     get('/ab', { a: 5 }, { random: { 1: 3 } }, [{ filter: 'random.1', valueId: '3', filterId: 'random_ab_test' }]);
     get('/ab', 4, { random: { 1: 9 } });
@@ -203,6 +213,13 @@ describe('get()', () => {
     get('/ab', 5, { random: { 1: 11 } });
     get('/ab', 5, { random: { 1: 19 } });
     get('/ab', 6, { random: { 1: 29 } });
+
+    get('/dpm1a', ['b']);
+    get('/dpm1b', ['b']);
+    get('/dpm2a', ['a', 'b']);
+    get('/dpm2b', ['a', 'b']);
+    get('/dpm3',  ['a', 'b']);
+    get('/dpm4',  ['a', 'b']);
 
     it('fails on invalid key', () => {
 


### PR DESCRIPTION
Issue 70: Document array behavior

This addresses https://github.com/hapipal/confidence/issues/70

The original intent of this PR was to simply update the `README.md` file to include an explanation that arrays are always merged.

Just getting set up in a Windows environment revealed an issue in `bin/confidence` (`annotate()` is not a function, and resolving the configuration path in Windows - tests have been added/updated for these).

Then, as I was developing the examples that I would put in the `README.md` file, I discovered that a base array declared as follows would not be detected as an array, and would be _overridden_ and *not* merged:
```
{
  $base: {
    $value: ['array']
  }
}
```

This led me to investigate how to make that functionality work consistently in all cases, hence the changes in `lib/store.js`.

After making those straightforward changes, I realized that I had no way to use Confidence for the use case posted in my original issue, which was the need for an array in the base configuration to be overridden by a filtered value.  

So, I investigated how to go about adding a flag to the base array, such that the behavior of merging or overriding the array could be controlled from within the definition of the configuration.  This led to the addition of the `$replace` flag and a custom Joi validation extension.

**This PR represents a breaking change.**  And also, it reveals the false assumption and inconsistent behavior that arrays were not always merged to begin with.  As such, I would appreciate some guidance.  If the maintainer(s) would like a separate PR that just updates the README and some test cases to better demonstrate _existing_ functionality so that it can be merged into the current release without introducing any breaking change, then I will be happy to generate that additional PR.  

Thanks!
