### PR TITLE
Upgrade deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.*
 **/.DS_Store
 **/._*
 
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - "8"
-  - "10"
   - "12"
   - "14"
   - "node"

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -133,7 +133,7 @@ exports.store = internals.store = internals.Joi.object().keys({
     $replace: internals.Joi.boolean().invalid(false),
     $env: internals.Joi.string().regex(/^\w+$/, { name: 'Alphanumeric Characters and "_"' }),
     $coerce: internals.Joi.string().valid('number', 'array', 'boolean', 'object'),
-    $splitToken : internals.Joi.alternatives([
+    $splitToken: internals.Joi.alternatives([
         internals.Joi.string(),
         internals.Joi.object().type(RegExp)
     ]),

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -2,130 +2,151 @@
 
 // Load modules
 
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 // Declare internals
 
 const internals = {};
 
-internals.Joi = Joi.extend([
-    {
-        name: 'object',
-        base: Joi.object(),
-        language: {
-            withPattern: 'fails to match the {{name}} pattern',
-            notInstanceOf: 'cannot be an instance of {{name}}',
-            replaceBaseArrayFlag: '{{desc}}'
-        },
-        rules: [
-            {
-                name: 'withPattern',
-                params: {
-                    key: Joi.string().required(),
-                    pattern: Joi.object().type(RegExp).required(),
-                    options: Joi.object().keys({
-                        name: Joi.string().required(),
-                        inverse: Joi.boolean().default(false)
-                    }).required()
-                },
-                validate(params, value, state, options) {
-
-                    if (Object.prototype.hasOwnProperty.call(value, params.key)) {
-                        let found = false;
-                        for (const key in value) {
-                            if (params.pattern.test(key)) {
-                                found = true;
-                                break;
-                            }
-                        }
-
-                        if (found !== params.options.inverse) {
-                            return this.createError('object.withPattern', { v: value, name: params.options.name }, state, options);
-                        }
-                    }
-
-                    return value;
-                }
-            },
-            {
-                name: 'notInstanceOf',
-                params: {
-                    fn: Joi.func().required()
-                },
-                validate(params, value, state, options) {
-
-                    if (value instanceof params.fn) {
-                        return this.createError('object.notInstanceOf', { v: value, name: params.fn.name }, state, options);
-                    }
-
-                    return value;
-                }
-            },
-            {
-                name: 'replaceBaseArrayFlag',
-                params: {},
-                validate(_params, value, state, options) {
-
-                    if (Object.keys(value).includes('$replace')) {
-                        if (!state.path.includes('$base')) {
-                            return this.createError('object.replaceBaseArrayFlag', { desc: '$replace only allowed under path $base' }, state, options);
-                        }
-
-                        if (!Object.keys(value).includes('$value')) {
-                            return this.createError('object.replaceBaseArrayFlag', { desc: '$replace missing required peer $value' }, state, options);
-                        }
-
-                        if (!Array.isArray(value.$value)) {
-                            return this.createError('object.replaceBaseArrayFlag', { desc: '$replace requires $value to be an array' }, state, options);
-                        }
-                    }
-
-                    return value;
-                }
-            }
-        ]
+internals.Joi = Joi.extend({
+    type: 'object',
+    base: Joi.object(),
+    messages: {
+        'object.withPattern': 'fails to match the {{#name}} pattern',
+        'object.notInstanceOf': 'cannot be an instance of {{#name}}',
+        'object.replaceBaseArrayFlag': '{{#desc}}'
     },
-    {
-        name: 'array',
-        base: Joi.array(),
-        language: {
-            sorted: 'entries are not sorted by {{name}}'
-        },
-        rules: [
-            {
-                name: 'sorted',
-                params: {
-                    fn: Joi.func().arity(2).required(),
-                    name: Joi.string().required()
-                },
-                validate(params, value, state, options) {
+    rules: {
+        withPattern: {
+            multi: true,
+            method(key, pattern, options) {
 
-                    let sorted = true;
-                    for (let i = 0; i < value.length - 1; ++i) {
-                        sorted = params.fn.call(null, value[i], value[i + 1]);
-                        if (!sorted) {
-                            return this.createError('array.sorted', { v: value, name: params.name }, state, options);
+                return this.$_addRule({ name: 'withPattern', args: { key, pattern, options } });
+            },
+            args: [
+                {
+                    name: 'key',
+                    assert: Joi.string().required()
+                },
+                {
+                    name: 'pattern',
+                    assert: Joi.object().instance(RegExp).required()
+                },
+                {
+                    name: 'options',
+                    assert: Joi.object().keys({
+                        name: Joi.string().required(),
+                        inverse: Joi.boolean()
+                    }).required()
+                }
+            ],
+            validate(value, helpers, args) {
+
+                if (Object.prototype.hasOwnProperty.call(value, args.key)) {
+                    let found = false;
+                    for (const key in value) {
+                        if (args.pattern.test(key)) {
+                            found = true;
+                            break;
                         }
                     }
 
-                    return value;
+                    if (found !== Boolean(args.options.inverse)) {
+                        return helpers.error('object.withPattern', { v: value, name: args.options.name });
+                    }
                 }
+
+                return value;
             }
-        ]
+        },
+        notInstanceOf: {
+            multi: true,
+            method(fn) {
+
+                return this.$_addRule({ name: 'notInstanceOf', args: { fn } });
+            },
+            args: [{
+                name: 'fn',
+                assert: Joi.func().required()
+            }],
+            validate(value, helpers, args) {
+
+                if (value instanceof args.fn) {
+                    return helpers.error('object.notInstanceOf', { v: value, name: args.fn.name });
+                }
+
+                return value;
+            }
+        },
+        replaceBaseArrayFlag: {
+            validate(value, helpers) {
+
+                if (Object.keys(value).includes('$replace')) {
+                    if (!helpers.state.path.includes('$base')) {
+                        return helpers.error('object.replaceBaseArrayFlag', { desc: '$replace only allowed under path $base' });
+                    }
+
+                    if (!Object.keys(value).includes('$value')) {
+                        return helpers.error('object.replaceBaseArrayFlag', { desc: '$replace missing required peer $value' });
+                    }
+
+                    if (!Array.isArray(value.$value)) {
+                        return helpers.error('object.replaceBaseArrayFlag', { desc: '$replace requires $value to be an array' });
+                    }
+                }
+
+                return value;
+            }
+        }
     }
-]);
-
-internals.alternatives = internals.Joi.lazy(() => {
-
-    return internals.Joi.alternatives([
-        internals.store,
-        internals.Joi.string().allow(''),
-        internals.Joi.number(),
-        internals.Joi.boolean(),
-        internals.Joi.array(),
-        internals.Joi.func()
-    ]);
 });
+
+internals.Joi = internals.Joi.extend({
+    type: 'array',
+    base: Joi.array(),
+    messages: {
+        'array.sorted': 'entries are not sorted by {{name}}'
+    },
+    rules: {
+        sorted: {
+            method(fn, name) {
+
+                return this.$_addRule({ name: 'sorted', args: { fn, name } });
+            },
+            args: [
+                {
+                    name: 'fn',
+                    assert: Joi.func().arity(2).required()
+                },
+                {
+                    name: 'name',
+                    assert: Joi.string().required()
+                }
+            ],
+            validate(value, helpers, args) {
+
+                let sorted = true;
+                for (let i = 0; i < value.length - 1; ++i) {
+                    sorted = args.fn.call(null, value[i], value[i + 1]);
+                    if (!sorted) {
+                        return helpers.error('array.sorted', { v: value, name: args.name });
+                    }
+                }
+
+                return value;
+            }
+        }
+    }
+});
+
+internals.alternatives = internals.Joi.alternatives([
+    internals.Joi.link('#store'),
+    internals.Joi.string().allow(''),
+    internals.Joi.number(),
+    internals.Joi.boolean(),
+    internals.Joi.array(),
+    internals.Joi.func()
+]);
 
 exports.store = internals.store = internals.Joi.object().keys({
     $param: internals.Joi.string().regex(/^\w+(?:\.\w+)*$/, { name: 'Alphanumeric Characters and "_"' }),
@@ -135,7 +156,7 @@ exports.store = internals.store = internals.Joi.object().keys({
     $coerce: internals.Joi.string().valid('number', 'array', 'boolean', 'object'),
     $splitToken: internals.Joi.alternatives([
         internals.Joi.string(),
-        internals.Joi.object().type(RegExp)
+        internals.Joi.object().instance(RegExp)
     ]),
     $filter: internals.Joi.alternatives([
         internals.Joi.string().regex(/^\w+(?:\.\w+)*$/, { name: 'Alphanumeric Characters and "_"' }),
@@ -173,4 +194,5 @@ exports.store = internals.store = internals.Joi.object().keys({
     .withPattern('$filter', /^((\$range)|([^\$].*))$/, { inverse: true, name: '$filter with a valid value OR $range' })
     .withPattern('$range', /^([^\$].*)$/, { name: '$range with non-ranged values' })
     .replaceBaseArrayFlag()
-    .allow(null);
+    .allow(null)
+    .id('store');

--- a/lib/store.js
+++ b/lib/store.js
@@ -191,7 +191,7 @@ internals.walk = function (node, criteria, applied) {
     }
 
     if (Object.prototype.hasOwnProperty.call(node, '$env')) {
-        const value = internals.coerce(Hoek.reach(process.env, node.$env, applied), node.$coerce || 'string', { splitToken : node.$splitToken || ',' });
+        const value = internals.coerce(Hoek.reach(process.env, node.$env, applied), node.$coerce || 'string', { splitToken: node.$splitToken || ',' });
 
         // Falls-through for $default
         if (typeof value === 'undefined' && node.$default) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "test": "lab -t 100 -a @hapi/code -L",
+    "lint-fix": "lab -t 100 -a @hapi/code -L --lint-fix",
     "test-cov-html": "lab -r html -o coverage.html -a @hapi/code -L"
   },
   "license": "BSD-3-Clause"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@hapi/hoek": "9.x.x",
     "alce": "1.x.x",
     "joi": "17.x.x",
-    "yargs": "13.x.x"
+    "yargs": "16.x.x"
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "api"
   ],
   "dependencies": {
-    "alce": "1.x.x",
-    "@hapi/hoek": "8.x.x",
+    "@hapi/hoek": "9.x.x",
     "@hapi/joi": "15.x.x",
+    "alce": "1.x.x",
     "yargs": "13.x.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "yargs": "13.x.x"
   },
   "devDependencies": {
-    "@hapi/code": "6.x.x",
+    "@hapi/code": "8.x.x",
     "@hapi/lab": "20.x.x"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   ],
   "dependencies": {
     "@hapi/hoek": "9.x.x",
-    "@hapi/joi": "15.x.x",
     "alce": "1.x.x",
+    "joi": "17.x.x",
     "yargs": "13.x.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/lab": "20.x.x"
+    "@hapi/lab": "23.x.x"
   },
   "bin": {
     "confidence": "bin/confidence"

--- a/test/store.js
+++ b/test/store.js
@@ -148,19 +148,18 @@ const tree = {
     },
 
     arrayReplace1: { $filter: 'env', $base: { $value: ['a'], $replace: true }, $default: { $value: ['b'] }, dev: ['c'] },
-    arrayReplace2: { $filter: 'env', $base: { $value: ['a'], $replace: true }, $default:           ['b'],   dev: [] },
-    arrayMerge1:   { $filter: 'env', $base: { $value: ['a']                 }, $default: { $value: ['b'] }, dev: ['c'] },
-    arrayMerge2:   { $filter: 'env', $base: { $value: ['a']                 }, $default:           ['b'],   dev: [] },
-    arrayMerge3:   { $filter: 'env', $base:           ['a'],                   $default: { $value: ['b'] }, dev: {} },
-    arrayMerge4:   { $filter: 'env', $base:           ['a'],                   $default:           ['b'],   dev: {} },
+    arrayReplace2: { $filter: 'env', $base: { $value: ['a'], $replace: true }, $default: ['b'],   dev: [] },
+    arrayMerge1: { $filter: 'env', $base: { $value: ['a']                   }, $default: { $value: ['b'] }, dev: ['c'] },
+    arrayMerge2: { $filter: 'env', $base: { $value: ['a']                   }, $default: ['b'],   dev: [] },
+    arrayMerge3: { $filter: 'env', $base: ['a'],                               $default: { $value: ['b'] }, dev: {} },
+    arrayMerge4: { $filter: 'env', $base: ['a'],                               $default: ['b'],   dev: {} },
+    coerceArray1: { $env: 'ARRAY', $coerce: 'array', $default: ['a'] },
+    coerceArray2: { $env: 'ARRAY', $coerce: 'array', $splitToken: '/', $default: ['a'] },
+    coerceArray3: { $env: 'ARRAY', $coerce: 'array', $splitToken: /-/i, $default: ['a'] },
 
-    coerceArray1: { $env: 'ARRAY', $coerce: 'array', $default : ['a'] },
-    coerceArray2: { $env: 'ARRAY', $coerce: 'array', $splitToken : '/', $default : ['a'] },
-    coerceArray3: { $env: 'ARRAY', $coerce: 'array', $splitToken : /-/i, $default : ['a'] },
+    coerceBoolean1: { $env: 'BOOLEAN', $coerce: 'boolean', $default: true },
 
-    coerceBoolean1: { $env: 'BOOLEAN', $coerce: 'boolean', $default : true },
-
-    coerceObject1: { $env: 'OBJECT', $coerce: 'object', $default : { a : 'b' } },
+    coerceObject1: { $env: 'OBJECT', $coerce: 'object', $default: { a: 'b' } },
 
     noProto: Object.create(null),
     $meta: {
@@ -225,13 +224,13 @@ describe('get()', () => {
         arrayReplace2: ['b'],
         arrayMerge1: ['a', 'b'],
         arrayMerge2: ['a', 'b'],
-        arrayMerge3:  ['a', 'b'],
-        arrayMerge4:  ['a', 'b'],
+        arrayMerge3: ['a', 'b'],
+        arrayMerge4: ['a', 'b'],
         coerceArray1: ['a'],
         coerceArray2: ['a'],
         coerceArray3: ['a'],
         coerceBoolean1: true,
-        coerceObject1: { a : 'b' }
+        coerceObject1: { a: 'b' }
     };
     get('/', slashResult);
     get('/', Object.assign({}, slashResult, { key3: { sub1: 0, sub2: '' }, ab: 6 }), { xfactor: 'yes' });
@@ -259,22 +258,22 @@ describe('get()', () => {
     get('/arrayMerge4',   {},         { env: 'dev' });
 
     get('/coerceArray1', ['a'], {}, [], {});
-    get('/coerceArray1', ['a', 'b'], {}, [], { ARRAY : 'a,b' });
-    get('/coerceArray1', ['a'], {}, [], { ARRAY : '' });
-    get('/coerceArray2', ['a', 'b'], {}, [], { ARRAY : 'a/b' });
-    get('/coerceArray3', ['a', 'b'], {}, [], { ARRAY : 'a-b' });
+    get('/coerceArray1', ['a', 'b'], {}, [], { ARRAY: 'a,b' });
+    get('/coerceArray1', ['a'], {}, [], { ARRAY: '' });
+    get('/coerceArray2', ['a', 'b'], {}, [], { ARRAY: 'a/b' });
+    get('/coerceArray3', ['a', 'b'], {}, [], { ARRAY: 'a-b' });
 
     get('/coerceBoolean1', true, {}, [], {});
-    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN' : 'true' });
-    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN' : 'TRUE' });
-    get('/coerceBoolean1', false, {}, [], { 'BOOLEAN' : 'false' });
-    get('/coerceBoolean1', false, {}, [], { 'BOOLEAN' : 'FALSE' });
-    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN' : 'NOT A BOOLEAN' });
-    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN' : '' });
+    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN': 'true' });
+    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN': 'TRUE' });
+    get('/coerceBoolean1', false, {}, [], { 'BOOLEAN': 'false' });
+    get('/coerceBoolean1', false, {}, [], { 'BOOLEAN': 'FALSE' });
+    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN': 'NOT A BOOLEAN' });
+    get('/coerceBoolean1', true, {}, [], { 'BOOLEAN': '' });
 
-    get('/coerceObject1', { a : 'b' }, {}, [], {});
-    get('/coerceObject1', { b : 'a' }, {}, [], { 'OBJECT' : '{"b":"a"}' });
-    get('/coerceObject1', { a : 'b' }, {}, [], { 'OBJECT' : 'BROKEN JSON' });
+    get('/coerceObject1', { a: 'b' }, {}, [], {});
+    get('/coerceObject1', { b: 'a' }, {}, [], { 'OBJECT': '{"b":"a"}' });
+    get('/coerceObject1', { a: 'b' }, {}, [], { 'OBJECT': 'BROKEN JSON' });
 
     it('fails on invalid key', () => {
 
@@ -357,12 +356,12 @@ describe('validate()', () => {
     validate('value with param', { key: { $value: 1, $param: 'a.b' } });
     validate('value with env', { key: { $value: 1, $env: 'NODE_ENV' } });
     validate('value with non-directive keys', { key: { $value: 1, a: 1 } });
-    validate('param with filter', { key: { $param : 'a.b', $filter: 'a' } });
-    validate('param with range', { key: { $param : 'a.b', $range: [{ limit: 10, value: 4 }] } });
-    validate('param with env', { key: { $param : 'a.b', $env: 'NODE_ENV' } });
+    validate('param with filter', { key: { $param: 'a.b', $filter: 'a' } });
+    validate('param with range', { key: { $param: 'a.b', $range: [{ limit: 10, value: 4 }] } });
+    validate('param with env', { key: { $param: 'a.b', $env: 'NODE_ENV' } });
     validate('param with non-directive keys', { key: { $param: 'a.b', a: 1 } });
-    validate('env with filter', { key: { $env : 'NODE_ENV', $filter: 'a' } });
-    validate('env with $range', { key: { $env : 'NODE_ENV', $range: [{ limit: 10, value: 4 }] } });
+    validate('env with filter', { key: { $env: 'NODE_ENV', $filter: 'a' } });
+    validate('env with $range', { key: { $env: 'NODE_ENV', $range: [{ limit: 10, value: 4 }] } });
     validate('env with non-directive keys', { key: { $env: 'NODE_ENV', a: 1 } });
     validate('filter without any value', { key: { $filter: '1' } });
     validate('filter with only default', { key: { $filter: 'a', $default: 1 } });


### PR DESCRIPTION
I encountered a problem while upgrading Joi from v15 to v17+. I rewrote the `.extend()` call to match the new API from v16. It seems that [the default](https://github.com/Nargonath/confidence/blob/d83de302ee2b06dda4d4cffc68d30fe8a1c7c280/lib/schema.js#L38) in the Joi schema for the `options` argument of the `withPattern` custom rule is not applied. It makes [this 
condition](https://github.com/Nargonath/confidence/blob/d83de302ee2b06dda4d4cffc68d30fe8a1c7c280/lib/schema.js#L53) fail whereas it should not. For the test on `$range` the `found` variable is `false` but `args.options.inverse` is undefined hence the strict equality comparison fails.

I don't know if it's normal and expected from the Joi rewrite and that I should just update the condition or if I made a mistake rewriting the `extend()` calls and the `default` should have worked. I don't have anymore time for today to work on it but I might be able to finish during the week-end. If anyone has an answer to this problem and wants to chime in, feel free to do so. 😃 