### PR TITLE
Replace yargs with bossy in CLI, remove support for ALCE file format

### DIFF
--- a/bin/confidence
+++ b/bin/confidence
@@ -12,12 +12,13 @@ internals.run = async () => {
 
     if (args instanceof Error) {
         console.error(args.message);
-        return process.exit(1);
+        process.exitCode = 1;
+        return;
     }
 
     if (args.help) {
         console.log(Bossy.usage(internals.definition, 'confidence -c config.json [--filter.criterion=value]'));
-        return process.exit(0);
+        return;
     }
 
     try {
@@ -28,7 +29,7 @@ internals.run = async () => {
     }
     catch (err) {
         console.error('Failed loading configuration file: ' + args.config + ' (' + err + ')');
-        process.exit(1);
+        process.exitCode = 1;
     }
 };
 

--- a/bin/confidence
+++ b/bin/confidence
@@ -1,73 +1,59 @@
 #!/usr/bin/env node
 'use strict';
 
-// Load modules
-
-const Fs = require('fs');
-const Path = require('path');
-const Yargs = require('yargs');
-const Alce = require('alce');
+const Bossy = require('@hapi/bossy');
 const Confidence = require('../');
-
-
-// Declare internals
 
 const internals = {};
 
-internals.checkArguments = function (argv) {
-    return typeof argv.indentation === 'number';
-};
+internals.run = async () => {
 
-internals.argv = Yargs.usage('Usage: $0 -c config.json [--filter.criterion=value]')
-                    .demand(['c'])
-                    .option('i', {
-                        alias: 'indentation',
-                        default: 4
-                    })
-                    .check(internals.checkArguments)
-                    .argv;
+    const args = Bossy.parse(internals.definition);
 
-internals.getConfig = function () {
+    if (args instanceof Error) {
+        console.error(args.message);
+        return process.exit(1);
+    }
 
-    const configPath = Path.resolve(internals.argv.c);
-
-    return new Promise((resolve, reject) => {
-
-        Fs.readFile(configPath, (err, data) => {
-
-            if (err) {
-                return reject(err);
-            }
-            try {
-                const config = Alce.parse(data);
-                return resolve(config);
-            }
-            catch (err) {
-                return reject(err);
-            }
-        });
-    });
-};
-
-
-internals.generate = async () => {
+    if (args.help) {
+        console.log(Bossy.usage(internals.definition, 'confidence -c config.json [--filter.criterion=value]'));
+        return process.exit(0);
+    }
 
     try {
-        const config = await internals.getConfig();
-        const store = new Confidence.Store(config);
-        const set = store.get('/', internals.argv.filter);
-        const indentation = internals.argv.indentation;
-    
-        if (!set) {
-            process.stderr.write('Failed to generate document');
-        }
-    
-        process.stdout.write(JSON.stringify(set, null, indentation));
+        const config = require(args.config);
+        const store = config instanceof Confidence.Store ? config : new Confidence.Store(config);
+        const result = store.get('/', args.filter);
+        process.stdout.write(JSON.stringify(result, null, args.indentation));
     }
     catch (err) {
-        process.stderr.write('Failed loading configuration file: ' + internals.argv.c + ' (' + err + ')');
+        console.error('Failed loading configuration file: ' + args.config + ' (' + err + ')');
         process.exit(1);
     }
 };
 
-internals.generate();
+
+internals.definition = {
+    h: {
+        type: 'help',
+        alias: 'help'
+    },
+    c: {
+        type: 'string',
+        require: true,
+        alias: 'config'
+    },
+    i: {
+        type: 'number',
+        alias: 'indentation',
+        default: 4
+    },
+    filter: {
+        type: 'json',
+        parsePrimitives: true,
+        default: {}
+    }
+};
+
+
+internals.run();

--- a/package.json
+++ b/package.json
@@ -11,14 +11,13 @@
     "api"
   ],
   "dependencies": {
+    "@hapi/bossy": ">=5.1.0 <6",
     "@hapi/hoek": "9.x.x",
-    "alce": "1.x.x",
-    "joi": "17.x.x",
-    "yargs": "16.x.x"
+    "joi": "17.x.x"
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/lab": "23.x.x",
+    "@hapi/lab": "24.x.x",
     "coveralls": "3.x.x"
   },
   "bin": {

--- a/test/bin.js
+++ b/test/bin.js
@@ -134,7 +134,7 @@ describe('bin', () => {
 
         expect(code).to.equal(1);
         expect(stdout).to.equal('');
-        expect(stderr).to.match(/Argument check failed[\s\S]*indentation/);
+        expect(stderr).to.match(/Invalid value \(non-number\) for option: i/);
     });
 
     it('fails when configuration file cannot be found', async () => {

--- a/test/bin.js
+++ b/test/bin.js
@@ -2,17 +2,12 @@
 
 // Load modules
 
-const ChildProcess = require('child_process');
-const Code = require('@hapi/code');
-const Fs = require('fs');
-const Lab = require('@hapi/lab');
 const Path = require('path');
+const { promises: Fs } = require('fs');
+const ChildProcess = require('child_process');
 
-
-// Declare internals
-
-const internals = {};
-
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
 
 // Test shortcuts
 
@@ -23,204 +18,131 @@ const before = lab.before;
 const after = lab.after;
 const it = lab.test;
 
-
-const confidencePath = Path.join(__dirname, '../', '/bin', '/confidence');
-const configPath = Path.join(__dirname, '/config.json');
-
-const tree = {
-    // Fork
-    key1: 'abc',                        // Value
-    key2: {
-        // Filter
-        $filter: 'env',
-        production: {
-            // Fork
-            deeper: {
-                // Value
-                $value: 'value'         // Value
-            }
-        },
-        $default: {
-            // Filter
-            $filter: 'platform',
-            ios: 1,                     // Value
-            $default: 2                 // Value
-        }
-    },
-    key3: {
-        // Fork
-        sub1: {
-            $value: 0,
-            $meta: 'something'
-        },
-        sub2: {
-            // Filter
-            $filter: 'xfactor',
-            $id: 'x_factor',
-            yes: ''                      // Value
-        }
-    },
-    key4: [12, 13, { $filter: 'none', x: 10, $default: 14 }],
-    key5: {},
-    ab: {
-        // Range
-        $filter: 'random.1',
-        $id: 'random_ab_test',
-        $range: [
-            { limit: 1, value: [1, 2] },
-            { limit: 2, value: { $value: 2 } },
-            { limit: 3, value: { a: 5 }, id: '3' },
-            { limit: 10, value: 4 },
-            { limit: 20, value: 5 }
-        ],
-        $default: 6
-    },
-    $meta: {
-        something: 'else'
-    }
-};
-
 describe('bin', () => {
 
-    before(() => {
+    const configPath = Path.join(__dirname, '/config.json');
+    const confidencePath = Path.join(__dirname, '../', '/bin', '/confidence');
 
-        return new Promise((resolve) => {
+    const tree = {
+        // Fork
+        key1: 'abc',                        // Value
+        key2: {
+            // Filter
+            $filter: 'env',
+            production: {
+                // Fork
+                deeper: {
+                    // Value
+                    $value: 'value'         // Value
+                }
+            },
+            $default: {
+                // Filter
+                $filter: 'platform',
+                ios: 1,                     // Value
+                $default: 2                 // Value
+            }
+        },
+        key3: {
+            // Fork
+            sub1: {
+                $value: 0,
+                $meta: 'something'
+            },
+            sub2: {
+                // Filter
+                $filter: 'xfactor',
+                $id: 'x_factor',
+                yes: ''                      // Value
+            }
+        },
+        key4: [12, 13, { $filter: 'none', x: 10, $default: 14 }],
+        key5: {},
+        ab: {
+            // Range
+            $filter: 'random.1',
+            $id: 'random_ab_test',
+            $range: [
+                { limit: 1, value: [1, 2] },
+                { limit: 2, value: { $value: 2 } },
+                { limit: 3, value: { a: 5 }, id: '3' },
+                { limit: 10, value: 4 },
+                { limit: 20, value: 5 }
+            ],
+            $default: 6
+        },
+        $meta: {
+            something: 'else'
+        }
+    };
 
-            const stream = Fs.createWriteStream(configPath);
-            stream.write(JSON.stringify(tree), 'utf8', () => {
+    before(async () => {
 
-                stream.end();
-                resolve();
-            });
-        });
+        await Fs.writeFile(configPath, JSON.stringify(tree));
     });
 
 
-    after(() => {
+    after(async () => {
 
-        return new Promise((resolve) => {
-
-            Fs.unlink(configPath, resolve);
-        });
+        await Fs.unlink(configPath);
     });
 
-    it('generates the correct config', () => {
+    const execute = (args) => {
 
         return new Promise((resolve) => {
 
-            const confidence = ChildProcess.spawn('node', [confidencePath, '-c', configPath]);
+            ChildProcess.execFile(confidencePath, args, (err, stdout, stderr) => {
 
-            confidence.stdout.on('data', (data) => {
-
-                const result = data.toString();
-                const obj = JSON.parse('{"key1":"abc","key2":2,"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
-                expect(result).to.equal(JSON.stringify(obj, null, 4));
-                confidence.kill();
-                resolve();
-            });
-
-            confidence.stderr.on('data', (data) => {
-
-                expect(data.toString()).to.not.exist();
+                resolve([err ? 1 : 0, stdout, stderr]);
             });
         });
+    };
 
+    it('generates the correct config', async () => {
 
+        const [code, stdout, stderr] = await execute(['-c', configPath]);
+
+        const obj = JSON.parse('{"key1":"abc","key2":2,"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
+        expect(code).to.equal(0);
+        expect(stdout).to.equal(JSON.stringify(obj, null, 4));
+        expect(stderr).to.equal('');
     });
 
-    it('generates the correct config', () => {
+    it('generates the correct config', async () => {
 
-        return new Promise((resolve) => {
+        const [code, stdout, stderr] = await execute(['-c', configPath, '--filter.env', 'production']);
 
-            const confidence = ChildProcess.spawn('node', [confidencePath, '-c', configPath, '--filter.env', 'production']);
-
-            confidence.stdout.on('data', (data) => {
-
-                const result = data.toString();
-                const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
-                expect(result).to.equal(JSON.stringify(obj, null, 4));
-                confidence.kill();
-                resolve();
-            });
-
-            confidence.stderr.on('data', (data) => {
-
-                expect(data.toString()).to.not.exist();
-            });
-        });
+        const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
+        expect(code).to.equal(0);
+        expect(stdout).to.equal(JSON.stringify(obj, null, 4));
+        expect(stderr).to.equal('');
     });
 
-    it('generates the correct config with custom indentation', () => {
+    it('generates the correct config with custom indentation', async () => {
 
-        return new Promise((resolve) => {
+        const [code, stdout, stderr] = await execute(['-c', configPath, '--filter.env', 'production', '-i', 2]);
 
-            const confidence = ChildProcess.spawn('node', [confidencePath, '-c', configPath, '--filter.env', 'production', '-i', 2]);
-
-            confidence.stdout.on('data', (data) => {
-
-                const result = data.toString();
-                const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
-                expect(result).to.equal(JSON.stringify(obj, null, 2));
-                confidence.kill();
-                resolve();
-            });
-
-            confidence.stderr.on('data', (data) => {
-
-                expect(data.toString()).to.not.exist();
-            });
-        });
+        const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
+        expect(code).to.equal(0);
+        expect(stdout).to.equal(JSON.stringify(obj, null, 2));
+        expect(stderr).to.equal('');
     });
 
-    it('fails when custom indentation is not a number', () => {
+    it('fails when custom indentation is not a number', async () => {
 
-        return new Promise((resolve) => {
+        const [code, stdout, stderr] = await execute(['-c', configPath, '--filter.env', 'production', '-i', 'someString']);
 
-            const errors = [];
-            const confidence = ChildProcess.spawn('node', [confidencePath, '-c', configPath, '--filter.env', 'production', '-i', 'someString']);
-
-            confidence.stdout.on('data', (data) => {
-
-                expect(data.toString()).to.not.exist();
-            });
-
-            confidence.stderr.on('data', (data) => {
-
-                expect(data.toString()).to.exist();
-                errors.push(data.toString());
-            });
-
-            confidence.on('close', () => {
-
-                expect(errors.join('')).to.match(/Argument check failed[\s\S]*indentation/);
-                resolve();
-            });
-        });
+        expect(code).to.equal(1);
+        expect(stdout).to.equal('');
+        expect(stderr).to.match(/Argument check failed[\s\S]*indentation/);
     });
 
-    it('fails when configuration file cannot be found', () => {
+    it('fails when configuration file cannot be found', async () => {
 
-        return new Promise((resolve) => {
+        const [code, stdout, stderr] = await execute(['-c', 'doesNotExist', '--filter.env', 'production', '-i', 2]);
 
-            const errors = [];
-            const confidence = ChildProcess.spawn('node', [confidencePath, '-c', 'doesNotExist', '--filter.env', 'production', '-i', 2]);
-
-            confidence.stdout.on('data', (data) => {
-
-                expect(data.toString()).to.not.exist();
-            });
-
-            confidence.stderr.on('data', (data) => {
-
-                expect(data.toString()).to.exist();
-                errors.push(data.toString());
-            });
-
-            confidence.on('close', () => {
-
-                expect(errors.join('')).to.match(/Failed loading configuration file: doesNotExist/);
-                resolve();
-            });
-        });
+        expect(code).to.equal(1);
+        expect(stdout).to.equal('');
+        expect(stderr).to.match(/Failed loading configuration file: doesNotExist/);
     });
 });


### PR DESCRIPTION
This work ALCE file format support from the confidence CLI, and is replaced with a plain `require()` which does still support JSON (and of course javascript with CJS exports).  The config file may also export a confidence store directly.  Lastly, yargs has been replaced with bossy, now possible due to bossy's object argument support https://github.com/hapijs/bossy/pull/77.  Lastly, I modernized the confidence bin tests.

Resolves #103 and resolves #105.