### PR TITLE
Add store.bind(), remove $env directive, misc fixes

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,9 +15,8 @@ Dynamic, declarative configurations
         - [`store.bind(criteria)`](#storebindcriteria)
 - [Document Format](#document-format)
     - [Basic Structure](#basic-structure)
-    - [Environment Variables](#environment-variables)
-        - [Coercing value](#coercing-value)
     - [Criteria Parameters](#criteria-parameters)
+        - [Coercing value](#coercing-value)
     - [Filters](#filters)
     - [Ranges](#ranges)
     - [Metadata](#metadata)
@@ -127,156 +126,6 @@ Keys can have children:
 }
 ```
 
-### Environment Variables
-
-In many scenarios, configuration documents may need to pull values from environment variables. Confidence allows you to refer to environment variables using `$env` directive.
-
-```json
-{
-    "mysql": {
-        "host": { "$env" : "MYSQL_HOST" },
-        "port": { "$env" : "MYSQL_PORT" },
-        "user": { "$env" : "MYSQL_USER" },
-        "password": { "$env" : "MYSQL_PASSWORD" },
-        "database": { "$env" : "MYSQL_DATABASE" },
-    }
-}
-```
-
-With following Enviornment Variables:
-
-```sh
-MYSQL_HOST=xxx.xxx.xxx.xxx
-MYSQL_PORT=3306
-MYSQL_USER=user1
-MYSQL_PASSWORD=some_password
-MYSQL_DATABASE=live_db
-```
-
-The result is:
-
-```json
-{
-    "mysql": {
-        "host": "xxx.xxx.xxx.xxx",
-        "port": "3306",
-        "user": "user1",
-        "password": "some_password",
-        "database": "live_db"
-    }
-}
-```
-
-`$default` directive allows to fallback to default values in case an environment variable is not set.
-
-```json
-{
-    "mysql": {
-        "host": { "$env" : "MYSQL_HOST" },
-        "port": { "$env" : "MYSQL_PORT", "$default": 3306 },
-        "user": { "$env" : "MYSQL_USER" },
-        "password": { "$env" : "MYSQL_PASSWORD" },
-        "database": { "$env" : "MYSQL_DATABASE" },
-    }
-}
-```
-
-With following Enviornment Variables:
-
-```sh
-MYSQL_HOST=xxx.xxx.xxx.xxx
-MYSQL_USER=user1
-MYSQL_PASSWORD=some_password
-MYSQL_DATABASE=live_db
-```
-
-The result is:
-
-```json
-{
-    "mysql": {
-        "host": "xxx.xxx.xxx.xxx",
-        "port": 3306,
-        "user": "user1",
-        "password": "some_password",
-        "database": "live_db"
-    }
-}
-```
-
-#### Coercing value
-
-`$coerce` directive allows you to coerce values to different types. In case the coercing fails, it falls back to `$default` directive, if present. Otherwise it return `undefined`.
-
-```json
-{
-    "mysql": {
-        "host": { "$env" : "MYSQL_HOST" },
-        "port": {
-            "$env" : "MYSQL_PORT",
-            "$coerce": "number",
-            "$default": 3306
-        },
-        "user": { "$env" : "MYSQL_USER" },
-        "password": { "$env" : "MYSQL_PASSWORD" },
-        "database": { "$env" : "MYSQL_DATABASE" },
-    }
-}
-```
-
-With following Environment Variables:
-
-```sh
-MYSQL_HOST=xxx.xxx.xxx.xxx
-MYSQL_PORT=3316
-MYSQL_USER=user1
-MYSQL_PASSWORD=some_password
-MYSQL_DATABASE=live_db
-```
-
-The result is:
-
-```json
-{
-    "mysql": {
-        "host": "xxx.xxx.xxx.xxx",
-        "port": 3316,
-        "user": "user1",
-        "password": "some_password",
-        "database": "live_db"
-    }
-}
-```
-With following Environment Variables:
-
-```sh
-MYSQL_HOST=xxx.xxx.xxx.xxx
-MYSQL_PORT=unknown
-MYSQL_USER=user1
-MYSQL_PASSWORD=some_password
-MYSQL_DATABASE=live_db
-```
-
-The result is:
-
-```json
-{
-    "mysql": {
-        "host": "xxx.xxx.xxx.xxx",
-        "port": 3306,
-        "user": "user1",
-        "password": "some_password",
-        "database": "live_db"
-    }
-}
-```
-
-Value can be coerced to :
- - `number` : applying `Number(value)`
- - `boolean` : checking whether the value equal `true` or `false` case insensitive
- - `array` : applying a `value.split(token)` with `token` (by default `','`) modifiable by setting the key `$splitToken` to either a string or a regex
- - `object` : applying a `JSON.parse(value)`
-
 ### Criteria Parameters
 
 In many scenarios, configuration documents may need to pull values fron `criteria`. Confidence allows you to refer to `criteria` using `$param` directive.
@@ -315,7 +164,7 @@ The result is:
 {
     "mysql": {
         "host": "xxx.xxx.xxx.xxx",
-        "port": "3306",
+        "port": 3306,
         "user": "user1",
         "password": "some_password",
         "database": "live_db"
@@ -368,6 +217,62 @@ The result is:
 }
 ```
 
+#### Coercing value
+
+`$coerce` directive allows you to coerce values to different types. In case the coercing fails, it falls back to `$default` directive, if present. Otherwise it returns `undefined`.
+
+```json
+{
+    "port": {
+        "$param" : "service.port",
+        "$coerce": "number",
+        "$default": 3000
+    }
+}
+```
+
+With following `criteria`:
+
+```json
+{
+    "service": {
+        "port": "4000"
+    }
+}
+```
+
+The result is:
+
+```json
+{
+    "port": 4000
+}
+```
+
+With following `criteria`:
+
+```json
+{
+    "service": {
+        "port": "unknown"
+    }
+}
+```
+
+The result is:
+
+```json
+{
+    "port": 3000
+}
+```
+
+Value can be coerced to:
+ - `number` : applying `Number(value)`.
+ - `boolean` : checking whether the value equal `true` or `false` case insensitive.
+ - `array` : applying a `value.split(token)` with `token` (by default `','`) modifiable by setting the key `$splitToken` to either a string or a regex.  Empty strings are coerced to `[]`.
+ - `object` : applying JSON parsing to the string.
+
 
 ### Filters
 
@@ -408,34 +313,6 @@ Filters can have a default value which will be used if the provided criteria set
         "$filter": "system.env",
         "production": 1,
         "$default": 2
-    }
-}
-```
-Filters can also refer to environment variables using `$env` directive.
-
-```json
-{
-    "key1": "abc",
-    "key2": {
-        "$filter": { "$env": "NODE_ENV" },
-        "production": {
-            "host": { "$env" : "MYSQL_HOST" },
-            "port": {
-                "$env" : "MYSQL_PORT",
-                "$coerce": "number",
-                "$default": 3306
-            },
-            "user": { "$env" : "MYSQL_USER" },
-            "password": { "$env" : "MYSQL_PASSWORD" },
-            "database": { "$env" : "MYSQL_DATABASE" },
-        },
-        "$default": {
-            "host": "127.0.0.1",
-            "port": 3306,
-            "user": "dev",
-            "password": "password",
-            "database": "dev_db"
-        }
     }
 }
 ```

--- a/API.md
+++ b/API.md
@@ -12,6 +12,7 @@ Dynamic, declarative configurations
         - [`store.load(document)`](#storeloaddocument)
         - [`store.get(key, [criteria])`](#storegetkey-criteria)
         - [`store.meta(key, [criteria])`](#storemetakey-criteria)
+        - [`store.bind(criteria)`](#storebindcriteria)
 - [Document Format](#document-format)
     - [Basic Structure](#basic-structure)
     - [Environment Variables](#environment-variables)
@@ -87,6 +88,15 @@ Returns the metadata found after applying the criteria. If the key is invalid or
 
 ```javascript
 const value = store.meta('/c', { size: 'big' });
+```
+
+#### `store.bind([criteria])`
+
+Binds criteria directly to the store, effectively setting it as default criteria.  When `criteria` is passed to [`store.get()`](#storegetkey-criteria) or [`store.meta()`](#storemetakey-criteria), it is merged into the bound criteria.  When `store.bind()` is called multiple times, the criteria from each call are merged together.  Calling `store.bind()` without an argument will reset the bound criteria.
+
+```javascript
+store.bind({ size: 'big' });
+const value = store.get('/c');
 ```
 
 ## Document Format

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -152,18 +152,12 @@ exports.store = internals.store = internals.Joi.object().keys({
     $param: internals.Joi.string().regex(/^\w+(?:\.\w+)*$/, { name: 'Alphanumeric Characters and "_"' }),
     $value: internals.alternatives,
     $replace: internals.Joi.boolean().invalid(false),
-    $env: internals.Joi.string().regex(/^\w+$/, { name: 'Alphanumeric Characters and "_"' }),
     $coerce: internals.Joi.string().valid('number', 'array', 'boolean', 'object'),
     $splitToken: internals.Joi.alternatives([
         internals.Joi.string(),
         internals.Joi.object().instance(RegExp)
     ]),
-    $filter: internals.Joi.alternatives([
-        internals.Joi.string().regex(/^\w+(?:\.\w+)*$/, { name: 'Alphanumeric Characters and "_"' }),
-        internals.Joi.object().keys({
-            $env: internals.Joi.string().regex(/^\w+$/, { name: 'Alphanumeric Characters and "_"' }).required()
-        })
-    ]),
+    $filter: internals.Joi.string().regex(/^\w+(?:\.\w+)*$/, { name: 'Alphanumeric Characters and "_"' }),
     $base: internals.alternatives,
     $default: internals.alternatives,
     $id: internals.Joi.string(),
@@ -180,14 +174,12 @@ exports.store = internals.store = internals.Joi.object().keys({
     .notInstanceOf(Error)
     .notInstanceOf(RegExp)
     .notInstanceOf(Date)
-    .without('$value', ['$filter', '$range', '$base', '$default', '$id', '$param', '$env'])
-    .without('$param', ['$filter', '$range', '$base', '$id', '$value', '$env'])
-    .without('$env', ['$filter', '$range', '$base', '$id', '$value', '$param'])
+    .without('$value', ['$filter', '$range', '$base', '$default', '$id', '$param'])
+    .without('$param', ['$filter', '$range', '$base', '$id', '$value'])
     .withPattern('$value', /^([^\$].*)$/, { name: '$value directive can only be used with $meta or $default or nothing' })
     .withPattern('$param', /^([^\$].*)$/, { name: '$param directive can only be used with $meta or $default or nothing' })
-    .withPattern('$env', /^([^\$].*)$/, { name: '$env directive can only be used with $meta or $default or nothing' })
-    .withPattern('$default', /^((\$param)|(\$filter)|(\$env))$/, { inverse: true, name: '$default directive requires $filter or $param or $env' })
-    .withPattern('$coerce', /^((\$param)|(\$env))$/, { inverse: true, name: '$coerce directive requires $param or $env' })
+    .withPattern('$default', /^((\$param)|(\$filter))$/, { inverse: true, name: '$default directive requires $filter or $param' })
+    .withPattern('$coerce', /^((\$param))$/, { inverse: true, name: '$coerce directive requires $param' })
     .with('$range', '$filter')
     .with('$base', '$filter')
     .with('$splitToken', '$coerce')

--- a/lib/store.js
+++ b/lib/store.js
@@ -13,6 +13,8 @@ module.exports = internals.Store = class Store {
 
     constructor(document) {
 
+        this._boundCriteria = {};
+
         this.load(document || {});
     }
 
@@ -22,9 +24,13 @@ module.exports = internals.Store = class Store {
         Hoek.assert(!err, err);
 
         this._tree = Hoek.clone(document);
+
+        return this;
     }
 
     get(key, criteria, applied) {
+
+        criteria = this._getCriteria(criteria);
 
         const node = internals.getNode(this._tree, key, criteria, applied);
         return internals.walk(node, criteria, applied);
@@ -32,8 +38,22 @@ module.exports = internals.Store = class Store {
 
     meta(key, criteria) {
 
+        criteria = this._getCriteria(criteria);
+
         const node = internals.getNode(this._tree, key, criteria);
         return (typeof node === 'object' ? node.$meta : undefined);
+    }
+
+    bind(criteria) {
+
+        this._boundCriteria = criteria === undefined ? {} : this._getCriteria(criteria);
+
+        return this;
+    }
+
+    _getCriteria(criteria) {
+
+        return Hoek.applyToDefaults(this._boundCriteria, criteria || {});
     }
 
     // Validate tree structure
@@ -74,8 +94,6 @@ module.exports = internals.Store = class Store {
 };
 
 internals.getNode = function (tree, key, criteria, applied) {
-
-    criteria = criteria || {};
 
     const path = [];
     if (key !== '/') {

--- a/lib/store.js
+++ b/lib/store.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Hoek = require('@hapi/hoek');
+const Bourne = require('@hapi/bourne');
 const Schema = require('./schema');
 
 // Declare internals
@@ -267,7 +268,7 @@ internals.coerce = function (value, type, options) {
             break;
         case 'object':
             try {
-                result = JSON.parse(value);
+                result = Bourne.parse(value);
             }
             catch (e) {
                 result = undefined;

--- a/lib/store.js
+++ b/lib/store.js
@@ -240,7 +240,7 @@ internals.coerce = function (value, type, options) {
             break;
         case 'array':
             if (typeof value === 'string') {
-                result = value.split(options.splitToken);
+                result = value ? value.split(options.splitToken) : [];
             }
             else {
                 result = undefined;

--- a/lib/store.js
+++ b/lib/store.js
@@ -153,7 +153,7 @@ internals.filter = function (node, criteria, applied) {
     // Filter
 
     const filter = node.$filter;
-    const criterion = typeof filter === 'object' ? Hoek.reach(process.env, filter.$env) : Hoek.reach(criteria, filter);
+    const criterion = Hoek.reach(criteria, filter);
 
     if (criterion !== undefined) {
         if (node.$range) {
@@ -195,11 +195,9 @@ internals.walk = function (node, criteria, applied) {
         return internals.walk(node.$value, criteria, applied);
     }
 
-    if (Object.prototype.hasOwnProperty.call(node, '$env') || Object.prototype.hasOwnProperty.call(node, '$param')) {
+    if (Object.prototype.hasOwnProperty.call(node, '$param')) {
 
-        const raw = Object.prototype.hasOwnProperty.call(node, '$param') ?
-            Hoek.reach(criteria, node.$param, applied) :
-            Hoek.reach(process.env, node.$env, applied);
+        const raw = Hoek.reach(criteria, node.$param, applied);
 
         const value = internals.coerce(raw, node.$coerce || 'string', { splitToken: node.$splitToken || ',' });
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "dependencies": {
     "@hapi/hoek": "9.x.x",
+    "@hapi/bourne": "2.x.x",
     "alce": "1.x.x",
     "joi": "17.x.x",
     "yargs": "16.x.x"

--- a/test/store.js
+++ b/test/store.js
@@ -405,6 +405,72 @@ describe('validate()', () => {
     });
 });
 
+describe('bind()', () => {
+
+    it('binds criteria for get()', () => {
+
+        const store = new Confidence.Store();
+        store.load(tree).bind({
+            a: { b: 1, c: 2 }
+        });
+
+        expect(store.get('/key10')).to.equal({ a: 1, b: 2 });
+        expect(store.get('/key10', { a: { b: 3 } })).to.equal({ a: 3, b: 2 });
+    });
+
+    it('binds criteria for meta()', () => {
+
+        const store = new Confidence.Store({
+            m: {
+                $filter: 'a.b',
+                x: {
+                    $meta: 'got x'
+                },
+                $default: {
+                    $meta: 'got default m'
+                }
+            },
+            n: {
+                $filter: 'a.c',
+                y: {
+                    $meta: 'got y'
+                },
+                $default: {
+                    $meta: 'got default n'
+                }
+            }
+        });
+
+        store.bind({
+            a: { b: 'x', c: 'z' }
+        });
+
+        expect(store.meta('/m')).to.equal('got x');
+        expect(store.meta('/n')).to.equal('got default n');
+        expect(store.meta('/m', { a: { b: 'z' } })).to.equal('got default m');
+        expect(store.meta('/n', { a: { c: 'y' } })).to.equal('got y');
+    });
+
+    it('accumulates bindings', () => {
+
+        const store = new Confidence.Store(tree);
+        store.bind({ a: { b: 1 } });
+        store.bind({ a: { c: 2 } });
+
+        expect(store.get('/key10')).to.equal({ a: 1, b: 2 });
+        expect(store.get('/key10', { a: { b: 3 } })).to.equal({ a: 3, b: 2 });
+    });
+
+    it('resets bindings when no arguments are passed', () => {
+
+        const store = new Confidence.Store(tree);
+        store.bind({ a: { b: 1, c: 2 } });
+        store.bind();
+
+        expect(store.get('/key10')).to.equal({ b: 123 });
+    });
+});
+
 describe('_logApplied', () => {
 
     it('adds the filter to the list of applied filters if node or criteria is not defined ', () => {

--- a/test/store.js
+++ b/test/store.js
@@ -213,7 +213,7 @@ describe('get()', () => {
 
     get('/coerceArray1', ['a'], {}, [], {});
     get('/coerceArray1', ['a', 'b'], { arr: 'a,b' }, []);
-    get('/coerceArray1', ['a'], { arr: '' }, []);
+    get('/coerceArray1', [], { arr: '' }, []);
     get('/coerceArray2', ['a', 'b'], { arr: 'a/b' }, []);
     get('/coerceArray3', ['a', 'b'], { arr: 'a-b' }, []);
 
@@ -221,7 +221,7 @@ describe('get()', () => {
     get('/coerceBoolean1', true, { bool: 'true' }, []);
     get('/coerceBoolean1', true, { bool: 'TRUE' }, []);
     get('/coerceBoolean1', false, { bool: 'false' }, []);
-    get('/coerceBoolean1', false, { bool: 'FALSE'}, []);
+    get('/coerceBoolean1', false, { bool: 'FALSE' }, []);
     get('/coerceBoolean1', true, { bool: 'NOT A BOOLEAN' }, []);
     get('/coerceBoolean1', true, { bool: '' }, []);
 

--- a/test/store.js
+++ b/test/store.js
@@ -228,6 +228,7 @@ describe('get()', () => {
     get('/coerceObject1', { a: 'b' }, {}, []);
     get('/coerceObject1', { b: 'a' }, { obj: '{"b":"a"}' }, []);
     get('/coerceObject1', { a: 'b' }, { obj: 'BROKEN JSON' }, []);
+    get('/coerceObject1', { a: 'b' }, { obj: '{"b":"a","__proto__":"x"}' }, []);
 
     it('fails on invalid key', () => {
 


### PR DESCRIPTION
Consider this a proposal to address #106: I understand that this work may not be used depending on whether we decide to keep `$env` or not.

The proposal here is to remove `$env`, while introducing a way to bind criteria to the store.  I consider this a generalization of `$env` because we can still use `$param` to reference environment variables.  The only thing missing was a way to make certain criteria "intrinsic" to the store (i.e. doesn't need to be explicitly passed to `store.get()`) in the same way that `process.env` was.  I personally like this approach because it's both more generic than `$env` and more explicit.  It also means that our confidence stores are more testable because bindings can be overridden, whereas before you would have to workaround this by patching `process.env`.  I found that the confidence test suite even had an issue due to the code it uses to patch `process.env`, and removing this code uncovered a bug!

Here's an example usage for a user who wants environment variables bound to their store:
```js
const store = new Confidence.Store({
    mysql: {
        host: { $param: 'env.MYSQL_HOST' },
        port: { $param: 'env.MYSQL_PORT', $coerce: 'number', $default: 3306 },
        user: { $param: 'env.MYSQL_USER' },
        password: { $param: 'env.MYSQL_PASSWORD' },
        database: { $param: 'env.MYSQL_DATABASE' }
    }
}).bind({ env: process.env });
```

Additional changes in here:
 - Array coercion for `''` now results in `[]` rather than `['']` (this was the `process.env`-related bug mentioned above).  The test suite actually expected `''` to be interpreted as missing with a fallback to default (though that was never the actual behavior), but this means there was no way to represent an empty array.  So I sort of split the difference.
 - Object coercion uses bourne now, and objects with `__proto__` are considered invalid.
 - `store.load()` (and `store.bind()`) return the store for fluent-style chaining.