### PR TITLE
Fix array coercion with empty string, protect from prototype poisoning

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -3,6 +3,7 @@
 // Load modules
 
 const Hoek = require('@hapi/hoek');
+const Bourne = require('@hapi/bourne');
 const Schema = require('./schema');
 
 // Declare internals
@@ -231,7 +232,7 @@ internals.coerce = function (value, type, options) {
             break;
         case 'array':
             if (typeof value === 'string') {
-                result = value.split(options.splitToken);
+                result = value ? value.split(options.splitToken) : [];
             }
             else {
                 result = undefined;
@@ -258,7 +259,7 @@ internals.coerce = function (value, type, options) {
             break;
         case 'object':
             try {
-                result = JSON.parse(value);
+                result = Bourne.parse(value);
             }
             catch (e) {
                 result = undefined;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "api"
   ],
   "dependencies": {
+    "@hapi/bourne": "2.x.x",
     "@hapi/hoek": "9.x.x",
     "alce": "1.x.x",
     "joi": "17.x.x",

--- a/test/store.js
+++ b/test/store.js
@@ -18,7 +18,7 @@ internals.replaceEnv = (obj) => {
 
     const replaced = {};
     for (const key in obj) {
-        if (obj[key]) {
+        if (key in obj && obj[key] !== null) {
             replaced[key] = process.env[key] ? process.env[key] : null;
             process.env[key] = obj[key];
         }
@@ -259,7 +259,7 @@ describe('get()', () => {
 
     get('/coerceArray1', ['a'], {}, [], {});
     get('/coerceArray1', ['a', 'b'], {}, [], { ARRAY: 'a,b' });
-    get('/coerceArray1', ['a'], {}, [], { ARRAY: '' });
+    get('/coerceArray1', [], {}, [], { ARRAY: '' });
     get('/coerceArray2', ['a', 'b'], {}, [], { ARRAY: 'a/b' });
     get('/coerceArray3', ['a', 'b'], {}, [], { ARRAY: 'a-b' });
 
@@ -274,6 +274,7 @@ describe('get()', () => {
     get('/coerceObject1', { a: 'b' }, {}, [], {});
     get('/coerceObject1', { b: 'a' }, {}, [], { 'OBJECT': '{"b":"a"}' });
     get('/coerceObject1', { a: 'b' }, {}, [], { 'OBJECT': 'BROKEN JSON' });
+    get('/coerceObject1', { a: 'b' }, { obj: '{"b":"a","__proto__":"x"}' }, []);
 
     it('fails on invalid key', () => {
 


### PR DESCRIPTION
Pulling some fixes out of #110 to ensure they land in v5:
 - Array coercion from string incorrectly interpreted `''` into `['']` rather than `[]`.
 - JSON parsing during object coercion protects from prototype poisoning using bourne.