### PR TITLE
Resolve null values when filtering array items

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -210,7 +210,8 @@ internals.walk = function (node, criteria, applied) {
         if (value !== undefined) {
             if (Array.isArray(parent)) {
                 parent.push(value);
-            }else {
+            }
+            else {
                 parent[key] = value;
             }
         }

--- a/lib/store.js
+++ b/lib/store.js
@@ -208,7 +208,11 @@ internals.walk = function (node, criteria, applied) {
         const child = internals.filter(node[key], criteria, applied);
         const value = internals.walk(child, criteria, applied);
         if (value !== undefined) {
-            parent[key] = value;
+            if (Array.isArray(parent)) {
+                parent.push(value);
+            }else {
+                parent[key] = value;
+            }
         }
     }
 

--- a/test/bin.js
+++ b/test/bin.js
@@ -58,6 +58,19 @@ describe('bin', () => {
         },
         key4: [12, 13, { $filter: 'none', x: 10, $default: 14 }],
         key5: {},
+        key6: [
+            {
+                // Filter
+                $filter: 'env',
+                production: 'chicken'
+            },
+            {
+                // Filter
+                $filter: 'env',
+                staging: 'cow'
+            },
+            15
+        ],
         ab: {
             // Range
             $filter: 'random.1',
@@ -102,7 +115,7 @@ describe('bin', () => {
 
         const [code, stdout, stderr] = await execute(['-c', configPath]);
 
-        const obj = JSON.parse('{"key1":"abc","key2":2,"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
+        const obj = JSON.parse('{"key1":"abc","key2":2,"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"key6":[15],"ab":6}');
         expect(code).to.equal(0);
         expect(stdout).to.equal(JSON.stringify(obj, null, 4));
         expect(stderr).to.equal('');
@@ -112,7 +125,7 @@ describe('bin', () => {
 
         const [code, stdout, stderr] = await execute(['-c', configPath, '--filter.env', 'production']);
 
-        const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
+        const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"key6":["chicken",15],"ab":6}');
         expect(code).to.equal(0);
         expect(stdout).to.equal(JSON.stringify(obj, null, 4));
         expect(stderr).to.equal('');
@@ -122,7 +135,7 @@ describe('bin', () => {
 
         const [code, stdout, stderr] = await execute(['-c', configPath, '--filter.env', 'production', '-i', 2]);
 
-        const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"ab":6}');
+        const obj = JSON.parse('{"key1":"abc","key2":{"deeper":"value"},"key3":{"sub1":0},"key4":[12,13,14],"key5":{},"key6":["chicken",15],"ab":6}');
         expect(code).to.equal(0);
         expect(stdout).to.equal(JSON.stringify(obj, null, 2));
         expect(stderr).to.equal('');


### PR DESCRIPTION
Addresses https://github.com/hapipal/confidence/issues/96

This issue occurred because, when filtering against multiple items in an array node, when we'd add a matching value, we'd do so by key assignment i.e. `parent[key] = value`. If the matched value were of index > 0 and prior indices had not been matched, this assignment would create a sparse array, which, when stringified, would show the empty indices as `null` (`JSON.stringify`'s behavior):

```js
const parent = [];
parent[1] = 'matched'
// parent is now [undefined, 'matched']
```
